### PR TITLE
Accept floating point for JWT timestamps

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -309,7 +309,9 @@ impl Client {
             aud: String,
             email: String,
             email_original: Option<String>,
+            #[serde(deserialize_with = "misc::deserialize_timestamp")]
             iat: u64,
+            #[serde(deserialize_with = "misc::deserialize_timestamp")]
             exp: u64,
             nonce: String,
         }


### PR DESCRIPTION
See: https://github.com/portier/portier-broker/pull/338

This shouldn't be a big problem currently, but just in case someone writes a broker implementation that creates JWTs like this, it now works with this client. 🙃